### PR TITLE
:pencil: fix URLs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -34,7 +34,7 @@ devtools::install_github("cboettig/duckdbfs")
 
 ## Quickstart
 
-```{r setup}
+```{r setup, message = FALSE}
 library(duckdbfs)
 library(dplyr)
 ```
@@ -43,12 +43,14 @@ Imagine we have a collection of URLs to files we want to combine into a single t
 
 
 ```{r example}
-base <- paste0("https://github.com/duckdb/duckdb/raw/master/",
-               "data/parquet-testing/hive-partitioning/union_by_name/")
-f1 <- paste0(base, "x=1/f1.parquet")
-f2 <- paste0(base, "x=1/f2.parquet")
-f3 <- paste0(base, "x=2/f2.parquet")
-urls <- c(f1,f2,f3)
+base <- paste0(
+  "https://github.com/duckdb/duckdb/raw/main/",
+  "data/parquet-testing/hive-partitioning/union_by_name/"
+)
+f1 <- paste0(base, "x%3D1/f1.parquet")
+f2 <- paste0(base, "x%3D1/f2.parquet")
+f3 <- paste0(base, "x%3D2/f2.parquet")
+urls <- c(f1, f2, f3)
 ```
 
 We can easily access this data without downloading by passing a vector of URLs. 
@@ -72,7 +74,7 @@ This is particularly convenient for accessing large, partitioned datasets, like 
 ```{r}
 parquet <- "s3://gbif-open-data-us-east-1/occurrence/2023-06-01/occurrence.parquet"
 duckdb_s3_config()
-gbif <- open_dataset(parquet, anonymous = TRUE, s3_region="us-east-1")
+gbif <- open_dataset(parquet, anonymous = TRUE, s3_region = "us-east-1")
 ```
 
 
@@ -95,9 +97,11 @@ using the `duckdb` implementation of the a method familiar to postgis, `ST_Point
 
 
 ```{r}
-spatial_ex <- paste0("https://raw.githubusercontent.com/cboettig/duckdbfs/",
-                     "main/inst/extdata/spatial-test.csv") |>
-  open_dataset(format = "csv") 
+spatial_ex <- paste0(
+  "https://raw.githubusercontent.com/cboettig/duckdbfs/",
+  "main/inst/extdata/spatial-test.csv"
+) |>
+  open_dataset(format = "csv")
 
 spatial_ex |>
   mutate(geometry = ST_Point(longitude, latitude)) |>
@@ -119,9 +123,9 @@ create our geometry column from lat/lon columns, and then compute the distance
 from each element to a spatial point:
 
 ```{r}
-spatial_ex |> 
+spatial_ex |>
   mutate(geometry = ST_Point(longitude, latitude)) |>
-  mutate(dist = ST_Distance(geometry, ST_Point(0,0))) |> 
+  mutate(dist = ST_Distance(geometry, ST_Point(0, 0))) |>
   to_sf()
 ```
 
@@ -132,7 +136,7 @@ For more details including a complete list of the dozens of spatial operations c
 Of course, `open_dataset()` can also be used with local files.  Remember that parquet format is not required, we can read csv files (including multiple and hive-partitioned csv files). 
 
 ```{r}
-write.csv(mtcars, "mtcars.csv", row.names=FALSE)
+write.csv(mtcars, "mtcars.csv", row.names = FALSE)
 lazy_cars <- open_dataset("mtcars.csv", format = "csv")
 ```
 


### PR DESCRIPTION
Hi @cboettig ,

I was trying to run the examples in the README and found some issues with the URLs, so I fixed them (and I muted dplyr's loading message). 
Anyway, thanks a lot for your work on this. 

<details>
```
R> sessionInfo()
R version 4.3.1 (2023-06-16)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Debian GNU/Linux trixie/sid

Matrix products: default
BLAS:   /usr/lib/x86_64-linux-gnu/openblas-pthread/libblas.so.3 
LAPACK: /usr/lib/x86_64-linux-gnu/openblas-pthread/libopenblasp-r0.3.23.so;  LAPACK version 3.11.0

locale:
 [1] LC_CTYPE=en_CA.UTF-8       LC_NUMERIC=C               LC_TIME=en_CA.UTF-8        LC_COLLATE=en_CA.UTF-8     LC_MONETARY=en_CA.UTF-8   
 [6] LC_MESSAGES=en_CA.UTF-8    LC_PAPER=en_CA.UTF-8       LC_NAME=C                  LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_CA.UTF-8 LC_IDENTIFICATION=C       

time zone: America/Toronto
tzcode source: system (glibc)

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

loaded via a namespace (and not attached):
 [1] digest_0.6.33     igraph_1.3.5      backports_1.4.1   utf8_1.2.3        R6_2.5.1          codetools_0.2-19  tidyselect_1.2.0 
 [8] xfun_0.39         targets_1.2.0     magrittr_2.0.3    glue_1.6.2        tibble_3.2.1      knitr_1.43        pkgconfig_2.0.3  
[15] lifecycle_1.0.3   ps_1.7.5          cli_3.6.1         fansi_1.0.4       processx_3.8.2    callr_3.7.3       vctrs_0.6.3      
[22] data.table_1.14.8 compiler_4.3.1    tools_4.3.1       pillar_1.9.0      yaml_2.3.7        base64url_1.4     rlang_1.1.1      

```

</details>