### PR TITLE
Feat/s3 writes

### DIFF
--- a/R/open_dataset.R
+++ b/R/open_dataset.R
@@ -27,6 +27,8 @@
 #' into RAM.  Using `TABLE` assumes familiarity with R's DBI-based interface.
 #' @param filename A logical value indicating whether to include the filename in
 #' the table name.
+#' @param recursive should we assume recursive path? default TRUE. Set to FALSE
+#' if trying to open a single, un-partitioned file.
 #' @param ... optional additional arguments passed to [duckdb_s3_config()].
 #'   Note these apply after those set by the URI notation and thus may be used
 #'   to override or provide settings not supported in that format.
@@ -62,9 +64,10 @@ open_dataset <- function(sources,
                          tblname = tmp_tbl_name(),
                          mode = "VIEW",
                          filename = FALSE,
+                         recursive = TRUE,
                          ...) {
 
-  sources <- parse_uri(sources, conn = conn)
+  sources <- parse_uri(sources, conn = conn, recursive = recursive)
 
   if(length(list(...)) > 0) { # can also be specified in URI query notation
     duckdb_s3_config(conn = conn, ...)

--- a/R/parse_uri.R
+++ b/R/parse_uri.R
@@ -37,6 +37,7 @@ parse_uri <- function(sources, conn, recursive = TRUE) {
 
     sources <- paste0(url$scheme, "://", url$hostname, url$path)
     if(recursive) {
+      sources <- gsub("\\/$", "", sources)
       sources <- paste0(sources, "/**")
     }
 

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -5,6 +5,9 @@
 #' or an in-memory data.frame.
 #' @param path a local file path or S3 path with write credentials
 #' @param conn duckdbfs database connection
+#' @param format export format
+#' @param partitioning names of columns to use as partition variables
+#' @param overwrite allow overwriting of existing files?
 #' @param ... additional arguments to [duckdb_s3_config()]
 #' @examplesIf interactive()
 #'   write_dataset(mtcars, tempfile())
@@ -13,9 +16,13 @@
 write_dataset <- function(dataset,
                           path,
                           conn = cached_connection(),
+                          format = c("parquet", "csv"),
+                          partitioning = dplyr::group_vars(dataset),
+                          overwrite = TRUE,
                           ...) {
-  version <- DBI::dbExecute(conn, "PRAGMA version;")
 
+  format <- match.arg(format)
+  version <- DBI::dbExecute(conn, "PRAGMA version;")
 
   if(is.null(dbplyr::remote_src(dataset))) {
 
@@ -30,17 +37,38 @@ write_dataset <- function(dataset,
 
   path <- parse_uri(path, conn = conn, recursive = FALSE)
 
-  if(grepl("^s3://", path)) {
-    load_httpfs(conn)
-    duckdb_s3_config(conn = conn, ...)
-
-    query <- paste("COPY", tblname, "TO", paste0("'", path, "'"))
-  } else {
-
-    query <- paste("COPY", tblname, "TO",
-                   paste0("'", path, "'"),
-                   "(FORMAT PARQUET);")
+  ## local writes use different notation to allow overwrites:
+  allow_overwrite <- character(0)
+  if(overwrite){
+    allow_overwrite <- paste("OVERWRITE_OR_IGNORE")
   }
+
+  if(grepl("^s3://", path)) {
+    duckdb_s3_config(conn = conn, ...)
+    if(overwrite){
+      allow_overwrite <- paste("ALLOW_OVERWRITE", overwrite)
+    }
+  }
+
+
+  format <- toupper(format)
+  partition_by <- character(0)
+  if(length(partitioning) > 0) {
+    partition_by <- paste0("PARTITION BY (",
+                           paste(partitioning, sep=", "),
+                           "), ")
+  }
+
+  options <-  paste0(
+                    paste("FORMAT", format), ", ",
+                    partition_by,
+                    allow_overwrite
+                   )
+
+  query <- paste("COPY", tblname, "TO",
+                 paste0("'", path, "'"),
+                 paste0("(",  options, ")"), ";")
+
 
   DBI::dbSendQuery(conn, query)
 }

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -46,7 +46,7 @@ write_dataset <- function(dataset,
   if(grepl("^s3://", path)) {
     duckdb_s3_config(conn = conn, ...)
     if(overwrite){
-      allow_overwrite <- paste("ALLOW_OVERWRITE", overwrite)
+     # allow_overwrite <- paste("ALLOW_OVERWRITE", overwrite)
     }
   }
 
@@ -58,9 +58,12 @@ write_dataset <- function(dataset,
                            paste(partitioning, sep=", "),
                            "), ")
   }
-
+  comma <- character(0)
+  if (length(c(partition_by, allow_overwrite) > 0)){
+    comma <- ", "
+  }
   options <-  paste0(
-                    paste("FORMAT", format), ", ",
+                    paste("FORMAT", "'parquet'"), comma,
                     partition_by,
                     allow_overwrite
                    )

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -24,8 +24,7 @@ write_dataset <- function(dataset,
   format <- match.arg(format)
   version <- DBI::dbExecute(conn, "PRAGMA version;")
 
-  if(is.null(dbplyr::remote_src(dataset))) {
-
+  if(is_not_remote(dataset)) {
     tblname = tmp_tbl_name()
     DBI::dbWriteTable(conn, name = tblname, value = dataset)
 
@@ -54,8 +53,8 @@ write_dataset <- function(dataset,
   format <- toupper(format)
   partition_by <- character(0)
   if(length(partitioning) > 0) {
-    partition_by <- paste0("PARTITION BY (",
-                           paste(partitioning, sep=", "),
+    partition_by <- paste0("PARTITION_BY (",
+                           paste(partitioning, collapse=", "),
                            "), ")
   }
   comma <- character(0)
@@ -74,4 +73,8 @@ write_dataset <- function(dataset,
 
 
   DBI::dbSendQuery(conn, query)
+}
+
+is_not_remote <- function(x) {
+  is.null(suppressWarnings(dbplyr::remote_src(x)))
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -16,9 +16,7 @@ dplyr
 duckdb
 duckdb's
 duckdb’s
-filepath
 filesize
-filesystems
 finalizer
 gc
 geospatial
@@ -34,6 +32,7 @@ postgis
 schemas
 tbl
 tibble
+un
 uploader
 vhost
 ’s

--- a/inst/examples/s3-tests.R
+++ b/inst/examples/s3-tests.R
@@ -1,0 +1,64 @@
+
+test_that("s3 minio", {
+
+  skip_on_os("windows")
+  skip_if_offline()
+  skip_on_cran()
+  skip_if_not_installed("minioclient")
+
+  # Hmm... this is quite an involved setup but...
+  # Put some parquet the MINIO test server:
+  base <- paste0("https://github.com/duckdb/duckdb/raw/main/",
+                 "data/parquet-testing/hive-partitioning/union_by_name/")
+  f1 <- paste0(base, "x=1/f1.parquet")
+  tmp <- tempfile(fileext = ".parquet")
+  download.file(f1, tmp, quiet = TRUE)
+  minioclient::mc("mb -p play/duckdbfs", verbose = FALSE)
+  minioclient::mc_cp(tmp, "play/duckdbfs")
+
+  # allow password-less access
+  minioclient::mc("anonymous set download play/duckdbfs", verbose=FALSE)
+
+  # Could set passwords here if necessary
+  duckdb_s3_config(s3_endpoint = "play.min.io",
+                   s3_url_style="path")
+  df <- open_dataset("s3://duckdbfs/")
+
+  expect_s3_class(df, "tbl")
+  expect_s3_class(df, "tbl_duckdb_connection")
+
+  minioclient::mc("rb --force play/duckdbfs", verbose = FALSE)
+
+})
+
+
+
+test_that("write_dataset to s3:", {
+
+  #  skip("S3 write not enabled")
+  skip_on_os("windows")
+  skip_if_offline()
+  skip_on_cran()
+  skip_if_not_installed("jsonlite")
+  skip_if_not_installed("minioclient")
+  minioclient::install_mc(force = TRUE)
+  p <- minioclient::mc_alias_ls("play --json")
+  config <- jsonlite::fromJSON(p$stdout)
+
+  minioclient::mc_mb("play/duckdbfs")
+
+  library(dplyr)
+
+  mtcars |> group_by(cyl, gear) |>
+  write_dataset("s3://duckdbfs/mtcars",
+                s3_access_key_id = config$accessKey,
+                s3_secret_access_key = config$secretKey,
+                s3_endpoint = config$URL,
+                s3_use_ssl=TRUE,
+                s3_url_style="path"
+  )
+
+  expect_true(TRUE)
+  minioclient::mc("rb --force play/duckdbfs")
+
+})

--- a/man/open_dataset.Rd
+++ b/man/open_dataset.Rd
@@ -14,6 +14,7 @@ open_dataset(
   tblname = tmp_tbl_name(),
   mode = "VIEW",
   filename = FALSE,
+  recursive = TRUE,
   ...
 )
 }
@@ -49,6 +50,9 @@ into RAM.  Using \code{TABLE} assumes familiarity with R's DBI-based interface.}
 
 \item{filename}{A logical value indicating whether to include the filename in
 the table name.}
+
+\item{recursive}{should we assume recursive path? default TRUE. Set to FALSE
+if trying to open a single, un-partitioned file.}
 
 \item{...}{optional additional arguments passed to \code{\link[=duckdb_s3_config]{duckdb_s3_config()}}.
 Note these apply after those set by the URI notation and thus may be used

--- a/man/write_dataset.Rd
+++ b/man/write_dataset.Rd
@@ -4,7 +4,15 @@
 \alias{write_dataset}
 \title{write_dataset}
 \usage{
-write_dataset(dataset, path, conn = cached_connection(), ...)
+write_dataset(
+  dataset,
+  path,
+  conn = cached_connection(),
+  format = c("parquet", "csv"),
+  partitioning = dplyr::group_vars(dataset),
+  overwrite = TRUE,
+  ...
+)
 }
 \arguments{
 \item{dataset}{a remote tbl object from \code{open_dataset},
@@ -13,6 +21,12 @@ or an in-memory data.frame.}
 \item{path}{a local file path or S3 path with write credentials}
 
 \item{conn}{duckdbfs database connection}
+
+\item{format}{export format}
+
+\item{partitioning}{names of columns to use as partition variables}
+
+\item{overwrite}{allow overwriting of existing files?}
 
 \item{...}{additional arguments to \code{\link[=duckdb_s3_config]{duckdb_s3_config()}}}
 }

--- a/tests/testthat/test-open_dataset.R
+++ b/tests/testthat/test-open_dataset.R
@@ -67,29 +67,12 @@ test_that("s3", {
   skip_on_os("windows")
   skip_if_offline()
   skip_on_cran()
-  skip_if_not_installed("minioclient")
-
-  # Hmm... this is quite an involved setup but...
-  # Put some parquet the MINIO test server:
-  base <- paste0("https://github.com/duckdb/duckdb/raw/main/",
-                 "data/parquet-testing/hive-partitioning/union_by_name/")
-  f1 <- paste0(base, "x=1/f1.parquet")
-  tmp <- tempfile(fileext = ".parquet")
-  download.file(f1, tmp, quiet = TRUE)
-  minioclient::mc("mb -p play/duckdbfs", verbose = FALSE)
-  minioclient::mc_cp(tmp, "play/duckdbfs")
-
-  # allow password-less access
-  minioclient::mc("anonymous set download play/duckdbfs", verbose=FALSE)
-
-  # Could set passwords here if necessary
-  duckdb_s3_config(s3_endpoint = "play.min.io",
-                   s3_url_style="path")
-  df <- open_dataset("s3://duckdbfs/")
-
-  expect_s3_class(df, "tbl")
-  expect_s3_class(df, "tbl_duckdb_connection")
-
-  minioclient::mc("rb --force play/duckdbfs", verbose = FALSE)
+  close_connection()
+  parquet <- "s3://gbif-open-data-us-east-1/occurrence/2023-06-01/occurrence.parquet"
+  gbif <- open_dataset(parquet,
+                       anonymous = TRUE,
+                       s3_region="us-east-1")
+  expect_s3_class(gbif, "tbl_dbi")
+  expect_s3_class(gbif, "tbl")
 
 })

--- a/tests/testthat/test-write_dataset.R
+++ b/tests/testthat/test-write_dataset.R
@@ -45,25 +45,28 @@ test_that("write_dataset, remote input", {
 
 test_that("write_dataset to s3:", {
 
-  skip("S3 write not enabled")
+#  skip("S3 write not enabled")
   skip_on_os("windows")
   skip_if_offline()
   skip_on_cran()
   skip_if_not_installed("jsonlite")
   skip_if_not_installed("minioclient")
-  minioclient::install_mc()
+  minioclient::install_mc(force = TRUE)
   p <- minioclient::mc_alias_ls("play --json")
   config <- jsonlite::fromJSON(p$stdout)
 
   minioclient::mc_mb("play/duckdbfs")
 
   write_dataset(mtcars,
-                "s3://duckdbfs/test",
+                "s3://duckdbfs/mtcars.parquet",
                 s3_access_key_id = config$accessKey,
                 s3_secret_access_key = config$secretKey,
-                s3_endpoint = config$URL
+                s3_endpoint = config$URL,
+                s3_use_ssl=TRUE,
+                s3_url_style="path"
                 )
 
-  minioclient::mc("rb play/duckdbfs")
+  expect_true(TRUE)
+  minioclient::mc("rb --force play/duckdbfs")
 
 })

--- a/tests/testthat/test-write_dataset.R
+++ b/tests/testthat/test-write_dataset.R
@@ -23,6 +23,25 @@ test_that("write_dataset", {
   expect_s3_class(df, "tbl")
 })
 
+test_that("write_dataset partitions", {
+
+  skip_on_cran()
+  ## write an in-memory dataset
+  path <- file.path(tempdir(), "mtcars")
+  library(dplyr)
+
+  mtcars |>
+    group_by(cyl, gear) |>
+    write_dataset(path)
+
+  expect_true(file.exists(path))
+  df <- open_dataset(path)
+  expect_s3_class(df, "tbl")
+  parts <- list.files(path)
+  expect_true(any(grepl("cyl=4", parts)))
+
+})
+
 
 test_that("write_dataset, remote input", {
   skip_on_cran()


### PR DESCRIPTION
ah, duckdb does already support creating partitions.  S3 support should now be working as well.  Should also benefit by faster uploads over s3 when using partitioning due to threading.  :crossed_fingers: 