### PR TITLE
 write now handles lazy queries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: duckdbfs
 Title: High Performance Remote File System Access Using 'duckdb'
-Version: 0.0.2-1
+Version: 0.0.3
 Authors@R: 
   person("Carl", "Boettiger", , "cboettig@gmail.com", c("aut", "cre"),
          comment = c(ORCID = "0000-0002-1642-628X"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# duckdbfs 0.0.3
+
+* `write_dataset()` now understands lazy queries, not just lazy tables.
+
 # duckdbfs 0.0.2
 
 * duckdbfs now has spatial data query support! Users can leverage spatial

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -33,7 +33,7 @@ write_dataset <- function(dataset,
 
   } else {
 
-    tblname <- as.character(dbplyr::remote_name(dataset))
+    tblname <- as.character(remote_name(dataset))
 
   }
 
@@ -82,3 +82,14 @@ write_dataset <- function(dataset,
 is_not_remote <- function(x) {
   is.null(suppressWarnings(dbplyr::remote_src(x)))
 }
+
+# Based on dbplyr
+remote_name <- function (x)
+{
+  lq <- x$lazy_query
+  if (inherits(lq, "lazy_base_remote_query")) {
+    return(lq$x)
+  }
+  lq$x$x
+}
+

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -33,7 +33,7 @@ write_dataset <- function(dataset,
 
   } else {
 
-    tblname <- as.character(remote_name(dataset))
+    tblname <- as.character(remote_name(dataset, conn))
 
   }
 
@@ -83,13 +83,12 @@ is_not_remote <- function(x) {
   is.null(suppressWarnings(dbplyr::remote_src(x)))
 }
 
-# Based on dbplyr
-remote_name <- function (x)
+
+remote_name <- function (x, con)
 {
-  lq <- x$lazy_query
-  if (inherits(lq, "lazy_base_remote_query")) {
-    return(lq$x)
-  }
-  paste(as.character(lq$x$x), collapse="")
+  out <- dbplyr::remote_name(x)
+  if(is.null(out))
+    out <- paste0("(", dbplyr::sql_render(x$lazy_query, con = con), ")")
+  out
 }
 

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -90,6 +90,6 @@ remote_name <- function (x)
   if (inherits(lq, "lazy_base_remote_query")) {
     return(lq$x)
   }
-  lq$x$x
+  paste(as.character(lq$x$x), collapse="")
 }
 

--- a/tests/testthat/test-write_dataset.R
+++ b/tests/testthat/test-write_dataset.R
@@ -21,6 +21,14 @@ test_that("write_dataset", {
   expect_true(file.exists(path))
   df <- open_dataset(path)
   expect_s3_class(df, "tbl")
+
+  ## Write from a query string
+  path2 <- file.path(tempdir(), "spatial2.parquet")
+
+  tbl |>
+    dplyr::mutate(new = "test") |>
+    write_dataset(path2)
+
 })
 
 test_that("write_dataset partitions", {


### PR DESCRIPTION
streamed writes to disk that involve lazy queries should now work, like this:

```r
 local_file <-  system.file("extdata/spatial-test.csv", package="duckdbfs")
 tbl <- open_dataset(local_file, format='csv')
 
  
  tbl |>
    dplyr::mutate(new = "test") |>
    write_dataset("test.parquet")
```