### PR TITLE
write options

### DIFF
--- a/man/write_dataset.Rd
+++ b/man/write_dataset.Rd
@@ -11,6 +11,7 @@ write_dataset(
   format = c("parquet", "csv"),
   partitioning = dplyr::group_vars(dataset),
   overwrite = TRUE,
+  options = list(),
   ...
 )
 }
@@ -28,6 +29,10 @@ or an in-memory data.frame.}
 
 \item{overwrite}{allow overwriting of existing files?}
 
+\item{options}{Additional arguments to COPY, see \url{https://duckdb.org/docs/stable/sql/statements/copy.html#copy--to-options}
+Note, uses duckdb native syntax, e.g. c("PER_THREAD_OUTPUT false"), for named arguments, see examples.
+(Recall SQL is case-insensitive).}
+
 \item{...}{additional arguments to \code{\link[=duckdb_s3_config]{duckdb_s3_config()}}}
 }
 \value{
@@ -42,5 +47,6 @@ write_dataset
 \dontshow{\}) # examplesIf}
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 write_dataset(mtcars, tempdir())
+write_dataset(mtcars, tempdir(), options = c("PER_THREAD_OUTPUT FALSE", "RETURN_STATS TRUE"))
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-write_dataset.R
+++ b/tests/testthat/test-write_dataset.R
@@ -7,6 +7,11 @@ test_that("write_dataset", {
   ## write an in-memory dataset
   path <- file.path(tempdir(), "mtcars.parquet")
   write_dataset(mtcars, path)
+  expect_true(file.exists(path))
+  df <- open_dataset(path)
+  expect_s3_class(df, "tbl")
+
+  write_dataset(mtcars, path, options = c("PER_THREAD_OUTPUT FALSE", "FILENAME_PATTERN 'cars_{i}'"))
 
   expect_true(file.exists(path))
   df <- open_dataset(path)
@@ -41,7 +46,7 @@ test_that("write_dataset partitions", {
 
   mtcars |>
     group_by(cyl, gear) |>
-    write_dataset(path)
+    write_dataset(path, options = "FILENAME_PATTERN 'cars_{uuid}'")
 
   expect_true(dir.exists(path))
   df <- open_dataset(path)
@@ -54,6 +59,8 @@ test_that("write_dataset partitions", {
   expect_true(file.exists(path))
   df <- open_dataset(path)
   expect_s3_class(df, "tbl")
+
+  unlink(path, recursive=TRUE)
 
 })
 
@@ -190,4 +197,5 @@ test_that("to_geojson s3", {
 
 
 })
+
 


### PR DESCRIPTION
support write options (e.g. "PER_THREAD_OUTPUT FALSE", which avoids creating a shard per thread.