### PR TITLE
utils: Hand conn from load_extension to duckdb_extensions

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -60,7 +60,7 @@ load_extension <-
     nightly = getOption("duckdbfs_use_nightly", FALSE),
     force = FALSE
   ) {
-    exts <- duckdb_extensions()
+    exts <- duckdb_extensions(conn = conn)
     source <- ""
     if (nightly) {
       source <- " FROM 'http://nightly-extensions.duckdb.org'"


### PR DESCRIPTION
Small problem I noticed whilst playing with duckdbfs, and wondering why the extension wasn't loading.

Had a look at #49, and appreciate that trying to use a DuckDB file & connection is "holding it wrong", but the parameter is there so someone is going to try and use it :)