### PR TITLE
Quick wins: fix #21, improve to_sf (#30/#18), docs for #44/#54

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # duckdbfs 0.1.2.99
 
 * `open_dataset()`, `spatial_join()`, and `write_dataset()` now quote the SQL identifier for the view/table name, so table names that start with a digit (e.g. file stems like `000016.parquet`) no longer produce a parser error ([#21](https://github.com/cboettig/duckdbfs/issues/21)).
+* `duckdb_config()` docs gain examples for common resource settings (`threads`, `memory_limit`, `temp_directory`, `max_temp_directory_size`) ([#44](https://github.com/cboettig/duckdbfs/issues/44)) and for HTTP retry/back-off (`http_retries`, `http_retry_wait_ms`) when a server returns HTTP 429 ([#54](https://github.com/cboettig/duckdbfs/issues/54)).
 * New function `raw_sql()` provides an escape hatch for executing arbitrary SQL and getting back a lazy `dplyr::tbl`, useful for DuckDB-specific syntax such as `UNION ALL BY NAME` that `dbplyr` does not emit.
 * `spatial_join()` now casts its geometry columns to plain `GEOMETRY`, avoiding a binder error from newer DuckDB spatial extensions when the two inputs have different CRS type tags (e.g. `EPSG:4326` vs `OGC:CRS84`).
 * All methods that write to a file / path now return that path (invisibly).  Previously the return was just inherited from dbExecute() call, except for write_dataset() which always followed this convention. An additional optional argument has been added which can format the returned path as an HTTP address. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # duckdbfs 0.1.2.99
 
 * `open_dataset()`, `spatial_join()`, and `write_dataset()` now quote the SQL identifier for the view/table name, so table names that start with a digit (e.g. file stems like `000016.parquet`) no longer produce a parser error ([#21](https://github.com/cboettig/duckdbfs/issues/21)).
+* `to_sf()` now reads native `GEOMETRY` columns directly instead of forcing a `ST_AsWKB` round-trip, and auto-populates `crs` from the column's CRS annotation (e.g. `GEOMETRY('EPSG:4326')`) when the caller hasn't supplied one ([#30](https://github.com/cboettig/duckdbfs/issues/30), [#18](https://github.com/cboettig/duckdbfs/issues/18)).
 * `duckdb_config()` docs gain examples for common resource settings (`threads`, `memory_limit`, `temp_directory`, `max_temp_directory_size`) ([#44](https://github.com/cboettig/duckdbfs/issues/44)) and for HTTP retry/back-off (`http_retries`, `http_retry_wait_ms`) when a server returns HTTP 429 ([#54](https://github.com/cboettig/duckdbfs/issues/54)).
 * New function `raw_sql()` provides an escape hatch for executing arbitrary SQL and getting back a lazy `dplyr::tbl`, useful for DuckDB-specific syntax such as `UNION ALL BY NAME` that `dbplyr` does not emit.
 * `spatial_join()` now casts its geometry columns to plain `GEOMETRY`, avoiding a binder error from newer DuckDB spatial extensions when the two inputs have different CRS type tags (e.g. `EPSG:4326` vs `OGC:CRS84`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # duckdbfs 0.1.2.99
 
+* `open_dataset()`, `spatial_join()`, and `write_dataset()` now quote the SQL identifier for the view/table name, so table names that start with a digit (e.g. file stems like `000016.parquet`) no longer produce a parser error ([#21](https://github.com/cboettig/duckdbfs/issues/21)).
 * New function `raw_sql()` provides an escape hatch for executing arbitrary SQL and getting back a lazy `dplyr::tbl`, useful for DuckDB-specific syntax such as `UNION ALL BY NAME` that `dbplyr` does not emit.
 * `spatial_join()` now casts its geometry columns to plain `GEOMETRY`, avoiding a binder error from newer DuckDB spatial extensions when the two inputs have different CRS type tags (e.g. `EPSG:4326` vs `OGC:CRS84`).
 * All methods that write to a file / path now return that path (invisibly).  Previously the return was just inherited from dbExecute() call, except for write_dataset() which always followed this convention. An additional optional argument has been added which can format the returned path as an HTTP address. 

--- a/R/duckdb_config.R
+++ b/R/duckdb_config.R
@@ -4,7 +4,15 @@
 #' @param ... named argument of the parameters to set, see examples
 #' see all possible configuration options at <https://duckdb.org/docs/sql/configuration.html>
 #' @return the active duckdb connection, invisibly
-#' @details Note: in I/O bound tasks such as streaming data, it can be helpful to set
+#' @details Accepts any duckdb setting as a named argument. Commonly useful:
+#'
+#' * `threads`, `memory_limit`, `temp_directory`, `max_temp_directory_size` —
+#'   resource tuning for large local jobs (see second example).
+#' * `http_retries`, `http_retry_wait_ms` — back off and retry when a remote
+#'   server returns HTTP 429 (rate-limited) or other transient errors while
+#'   streaming parquet / CSV over HTTP(S).
+#'
+#' Note: in I/O bound tasks such as streaming data, it can be helpful to set
 #' thread parallelism significantly higher than available CPU cores.
 #' @seealso duckdb_reset, duckdb_get_config
 #' @export
@@ -12,6 +20,17 @@
 #' duckdb_config(threads = 1, memory_limit = '10GB')
 #' duckdb_get_config("threads")
 #' duckdb_reset("threads")
+#'
+#' # Common settings for larger local jobs
+#' duckdb_config(
+#'   threads = 64,
+#'   memory_limit = "30GB",
+#'   temp_directory = "/tmp/duckdb_swap",
+#'   max_temp_directory_size = "100GB"
+#' )
+#'
+#' # Retry HTTP requests (e.g. a server returning HTTP 429 on parquet reads)
+#' duckdb_config(http_retries = 5, http_retry_wait_ms = 2000)
 duckdb_config <- function(..., conn = cached_connection()) {
   parameters <- list(...)
   for (p in names(parameters)) {

--- a/R/open_dataset.R
+++ b/R/open_dataset.R
@@ -95,7 +95,7 @@ open_dataset <- function(sources,
     # for now VSI prefixes are not supported, but httpfs can handle spatial
     sources <- strip_vsi(sources)
   }
-  view_query <- query_string(tblname,
+  view_query <- query_string(DBI::dbQuoteIdentifier(conn, tblname),
                              sources,
                              format = format,
                              mode = mode,

--- a/R/spatial_join.R
+++ b/R/spatial_join.R
@@ -136,7 +136,8 @@ as_view <- function(x, tblname =  tmp_tbl_name(), conn = cached_connection()) {
 query_to_view <- function(query,
                           tblname =  tmp_tbl_name(),
                           conn = cached_connection()) {
-  q <- paste("CREATE OR REPLACE TEMPORARY VIEW", tblname, "AS", query)
+  q <- paste("CREATE OR REPLACE TEMPORARY VIEW",
+             DBI::dbQuoteIdentifier(conn, tblname), "AS", query)
   DBI::dbSendQuery(conn, q)
   dplyr::tbl(conn, tblname)
 }

--- a/R/to_sf.R
+++ b/R/to_sf.R
@@ -4,6 +4,9 @@
 #'
 #' @param x a remote duckdb `tbl` (from `open_dataset`) or dplyr-pipeline thereof.
 #' @param crs The coordinate reference system, any format understood by `sf::st_crs`.
+#' If `NA` (the default), `to_sf()` will pick up the CRS from the column's
+#' `GEOMETRY('...')` type annotation when one is present (e.g. when reading
+#' a georeferenced file via `open_dataset(format = "sf")`).
 #' @param conn the connection object from the tbl.
 #' Takes a duckdb table (from `open_dataset`) or a dataset or dplyr
 #' pipline and returns an sf object. **Important**: the table must have
@@ -47,18 +50,57 @@ to_sf <- function(x,
 
   if("geometry" %in% colnames(x)) {
     x <- x |> dplyr::rename(geom=geometry)
-    geometry_column <- "geom"
   }
-  sql <- x |>
-    dplyr::mutate(geom = ST_AsWKB(geom)) |>
-    dbplyr::sql_render()
+
+  # Inspect the query's geom column type. Native GEOMETRY columns can be
+  # read directly by sf; only BLOB / unknown columns need an explicit cast
+  # to WKB. GEOMETRY types also carry their CRS annotation, which we use
+  # as the default when the caller hasn't supplied `crs`.
+  geom_info <- geom_column_info(x, conn, "geom")
+
+  if (geom_info$is_geometry) {
+    sql <- dbplyr::sql_render(x)
+  } else {
+    sql <- x |>
+      dplyr::mutate(geom = ST_AsWKB(geom)) |>
+      dbplyr::sql_render()
+  }
 
   requireNamespace("sf", quietly = TRUE)
   out <- sf::st_read(conn, query=sql, geometry_column = "geom")
+
+  if (is.na(crs) && !is.na(geom_info$crs)) {
+    crs <- geom_info$crs
+  }
   if (!is.na(crs)) {
     sf::st_crs(out) <- crs
   }
   out
+}
+
+# Internal: inspect a geom column in a lazy query. Returns a list with
+#   is_geometry: TRUE when the column type starts with "GEOMETRY"
+#   crs: character (e.g. "EPSG:4326") parsed from the type annotation, or NA
+geom_column_info <- function(x, conn, col = "geom") {
+  default <- list(is_geometry = FALSE, crs = NA_character_)
+
+  sql <- tryCatch(dbplyr::sql_render(x), error = function(e) NULL)
+  if (is.null(sql)) return(default)
+
+  schema <- tryCatch(
+    DBI::dbGetQuery(conn, paste0("DESCRIBE ", sql)),
+    error = function(e) NULL
+  )
+  if (is.null(schema) || !(col %in% schema$column_name)) return(default)
+
+  col_type <- schema$column_type[schema$column_name == col][[1]]
+  if (!grepl("^GEOMETRY", col_type)) return(default)
+
+  crs <- NA_character_
+  m <- regmatches(col_type, regexec("GEOMETRY\\('([^']+)'\\)", col_type))[[1]]
+  if (length(m) >= 2) crs <- m[[2]]
+
+  list(is_geometry = TRUE, crs = crs)
 }
 
 utils::globalVariables(c("ST_AsWKB", "geom", "geometry"), package = "duckdbfs")

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -39,8 +39,17 @@ write_dataset <- function(
   if (is_not_remote(dataset)) {
     tblname = tmp_tbl_name()
     DBI::dbWriteTable(conn, name = tblname, value = dataset)
+    src <- DBI::dbQuoteIdentifier(conn, tblname)
   } else {
-    tblname <- as.character(remote_name(dataset, conn))
+    # remote_name() returns either a bare identifier (dbplyr::remote_name)
+    # or a parenthesized sub-SELECT (when the lazy query has been mutated).
+    # Quote the former as an identifier; pass the sub-SELECT through verbatim.
+    bare <- dbplyr::remote_name(dataset)
+    if (is.null(bare)) {
+      src <- as.character(remote_name(dataset, conn))
+    } else {
+      src <- DBI::dbQuoteIdentifier(conn, as.character(bare))
+    }
   }
 
   ## local writes use different notation to allow overwrites:
@@ -68,7 +77,7 @@ write_dataset <- function(
   options_vec <- c(format_by, partition_by, allow_overwrite, options)
   copy_options <- glue::glue_collapse(options_vec, sep = ", ")
 
-  copy <- glue::glue("COPY {DBI::dbQuoteIdentifier(conn, tblname)} TO '{path}' ")
+  copy <- glue::glue("COPY {src} TO '{path}' ")
   query <- glue::glue(copy, "({copy_options})", ";")
   status <- DBI::dbSendQuery(conn, query)
 

--- a/R/write_dataset.R
+++ b/R/write_dataset.R
@@ -68,7 +68,7 @@ write_dataset <- function(
   options_vec <- c(format_by, partition_by, allow_overwrite, options)
   copy_options <- glue::glue_collapse(options_vec, sep = ", ")
 
-  copy <- glue::glue("COPY {tblname} TO '{path}' ")
+  copy <- glue::glue("COPY {DBI::dbQuoteIdentifier(conn, tblname)} TO '{path}' ")
   query <- glue::glue(copy, "({copy_options})", ";")
   status <- DBI::dbSendQuery(conn, query)
 

--- a/man/duckdb_config.Rd
+++ b/man/duckdb_config.Rd
@@ -19,6 +19,15 @@ the active duckdb connection, invisibly
 duckdb configuration
 }
 \details{
+Accepts any duckdb setting as a named argument. Commonly useful:
+\itemize{
+\item \code{threads}, \code{memory_limit}, \code{temp_directory}, \code{max_temp_directory_size} —
+resource tuning for large local jobs (see second example).
+\item \code{http_retries}, \code{http_retry_wait_ms} — back off and retry when a remote
+server returns HTTP 429 (rate-limited) or other transient errors while
+streaming parquet / CSV over HTTP(S).
+}
+
 Note: in I/O bound tasks such as streaming data, it can be helpful to set
 thread parallelism significantly higher than available CPU cores.
 }
@@ -27,6 +36,17 @@ thread parallelism significantly higher than available CPU cores.
 duckdb_config(threads = 1, memory_limit = '10GB')
 duckdb_get_config("threads")
 duckdb_reset("threads")
+
+# Common settings for larger local jobs
+duckdb_config(
+  threads = 64,
+  memory_limit = "30GB",
+  temp_directory = "/tmp/duckdb_swap",
+  max_temp_directory_size = "100GB"
+)
+
+# Retry HTTP requests (e.g. a server returning HTTP 429 on parquet reads)
+duckdb_config(http_retries = 5, http_retry_wait_ms = 2000)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -10,13 +10,6 @@ library(testthat)
 library(duckdbfs)
 
 
-has_spatial <- function() {
-    duckdbfs::duckdb_extensions() |>
-        dplyr::filter(extension_name == "spatial") |>
-        dplyr::pull(installed)
-}
-
-
 # tests that don't need extensions loaded shouldn't access internet
 #options("duckdbfs_autoload_extensions" = FALSE)
 

--- a/tests/testthat/helper-spatial.R
+++ b/tests/testthat/helper-spatial.R
@@ -1,0 +1,5 @@
+has_spatial <- function() {
+  duckdbfs::duckdb_extensions() |>
+    dplyr::filter(extension_name == "spatial") |>
+    dplyr::pull(installed)
+}

--- a/tests/testthat/test-open_dataset.R
+++ b/tests/testthat/test-open_dataset.R
@@ -82,6 +82,21 @@ test_that("s3", {
 
 
 
+test_that("digit-prefixed tblnames are quoted (issue #21)", {
+  tmp <- tempfile(fileext = ".parquet")
+  conn <- cached_connection()
+  DBI::dbWriteTable(conn, "mtcars_src", mtcars, overwrite = TRUE)
+  DBI::dbExecute(conn, paste0("COPY mtcars_src TO '", tmp, "' (FORMAT PARQUET);"))
+
+  df <- open_dataset(tmp, format = "parquet", tblname = "000001", conn = conn)
+  expect_true(inherits(df, "tbl_duckdb_connection"))
+  out <- dplyr::collect(df)
+  expect_equal(nrow(out), nrow(mtcars))
+
+  unlink(tmp)
+  close_connection()
+})
+
 test_that("custom csv parsing", {
   cars <- tempfile()
   write.table(mtcars, cars, row.names = FALSE)

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -35,6 +35,26 @@ test_that("spatial vector read", {
 })
 
 
+test_that("to_sf() reads native GEOMETRY without WKB cast and picks up CRS", {
+  skip_if_not_installed("sf")
+  skip_if_offline()
+  skip_on_cran()
+  skip_if_not(has_spatial(), "spatial extension not available")
+
+  path <- system.file("extdata/world.fgb", package = "duckdbfs")
+  x <- open_dataset(path, format = "sf")
+
+  # the source declares EPSG:4326; to_sf() should pick that up automatically
+  y <- to_sf(x)
+  expect_s3_class(y, "sf")
+  expect_equal(sf::st_crs(y), sf::st_crs("EPSG:4326"))
+
+  # explicit user-supplied crs should still win
+  z <- to_sf(x, crs = "EPSG:3857")
+  expect_equal(sf::st_crs(z), sf::st_crs("EPSG:3857"))
+})
+
+
 test_that("spatial_join", {
   skip_if_not_installed("sf")
   skip_if_offline() # needs to be able to load the spatial module


### PR DESCRIPTION
## Summary

Five issue fixes, plus a pre-existing test-harness cleanup.

### Fixes

- **#21** — `open_dataset()`, `spatial_join()`, and `write_dataset()` now wrap the view/table name with `DBI::dbQuoteIdentifier()`, so table names that start with a digit (e.g. file stems like `000016.parquet`) no longer trip a DuckDB parser error. Regression test added.
- **#30 / #18** — `to_sf()` now inspects the `geom` column type via `DESCRIBE <query>` and reads native `GEOMETRY` columns directly, skipping the `ST_AsWKB` round-trip. Where the type carries a CRS annotation (e.g. `GEOMETRY('EPSG:4326')`), that CRS becomes the default when the caller hasn't supplied `crs`, so `to_sf(open_dataset(..., format = "sf"))` returns a properly georeferenced `sf` object without manual `crs=` wiring.
- **#44 / #54** — `duckdb_config()` already handles arbitrary named settings; just needed discoverable examples. Added examples for the common resource cluster (`threads`, `memory_limit`, `temp_directory`, `max_temp_directory_size`) and for HTTP retry/back-off (`http_retries`, `http_retry_wait_ms`) when a server returns HTTP 429.

### Test-harness cleanup

- Moved `has_spatial()` from `tests/testthat.R` (sourced only by `R CMD check`) to `tests/testthat/helper-spatial.R` (sourced by `devtools::test()`). Interactive runs no longer error on the `skip_if_not(has_spatial(), ...)` guards; CI is unaffected.
- Also fixed a latent regression in `write_dataset()` that the identifier-quoting change surfaced: when the input is a transformed lazy tbl, `remote_name()` returns a parenthesised sub-SELECT rather than a bare identifier, so only the bare-name path should be quoted.

### Result

Full test suite under \`NOT_CRAN=true\`: \`FAIL 0 | WARN 0 | SKIP 0 | PASS 72\`.

## Test plan

- [x] \`devtools::test()\` passes clean with \`NOT_CRAN=true\`
- [x] New regression test for issue #21 (digit-prefixed tblname)
- [x] New test asserting \`to_sf()\` auto-populates CRS from \`GEOMETRY('EPSG:4326')\`
- [x] Explicit user-supplied \`crs =\` still wins over the inferred CRS
- [ ] \`R CMD check\` clean (expect clean, CI will confirm)