### PR TITLE
Docs: cached_connection cache semantics + file-vs-database article

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^todo\.md$
+^vignettes/articles$

--- a/R/cached_connection.R
+++ b/R/cached_connection.R
@@ -26,6 +26,34 @@ duckdbfs_env <- new.env()
 #' effectively support most operations on much-larger-than-RAM data.
 #' However, some operations require additional working space, so by default
 #' we set a temporary storage location in configuration as well.
+#'
+#' @section On-disk storage and the connection cache:
+#' Pass `dbdir = "/path/to/db.duckdb"` to back the connection with a local
+#' on-disk database file from the start (useful for operations that benefit
+#' from indexing, e.g. R-tree spatial indexes, or for heavy repeated local
+#' queries).
+#'
+#' **Gotcha:** the connection cache is sticky. On the first call, this
+#' function caches whatever connection it creates; every subsequent call
+#' returns that same connection and **ignores new arguments** (including
+#' `dbdir`). If you want to change the backing store, call
+#' [close_connection()] first, then call `cached_connection()` again with
+#' the new `dbdir`. Trying to pass the path of an *existing* DuckDB database
+#' file via `cached_connection(dbdir = ...)` after the cache is populated
+#' is the common trap (see issue #49).
+#'
+#' If you want to manage a connection yourself — e.g. to open an existing
+#' duckdb database file, or to share a connection across other DBI-based
+#' code — create it directly and pass it to `duckdbfs` functions via
+#' the `conn` argument:
+#'
+#' ```r
+#' con <- DBI::dbConnect(duckdb::duckdb(), dbdir = "my.duckdb")
+#' open_dataset("s3://bucket/data", conn = con)
+#' ```
+#'
+#' See the "File-based vs database-based workflows" article for the broader
+#' design philosophy.
 #' @inheritParams duckdb::duckdb
 #' @param autoload_exts should we auto-load extensions?  TRUE by default,
 #' can be configured with `options(duckdbfs_autoload_extensions = FALSE)`

--- a/man/cached_connection.Rd
+++ b/man/cached_connection.Rd
@@ -72,6 +72,35 @@ effectively support most operations on much-larger-than-RAM data.
 However, some operations require additional working space, so by default
 we set a temporary storage location in configuration as well.
 }
+\section{On-disk storage and the connection cache}{
+
+Pass \code{dbdir = "/path/to/db.duckdb"} to back the connection with a local
+on-disk database file from the start (useful for operations that benefit
+from indexing, e.g. R-tree spatial indexes, or for heavy repeated local
+queries).
+
+\strong{Gotcha:} the connection cache is sticky. On the first call, this
+function caches whatever connection it creates; every subsequent call
+returns that same connection and \strong{ignores new arguments} (including
+\code{dbdir}). If you want to change the backing store, call
+\code{\link[=close_connection]{close_connection()}} first, then call \code{cached_connection()} again with
+the new \code{dbdir}. Trying to pass the path of an \emph{existing} DuckDB database
+file via \code{cached_connection(dbdir = ...)} after the cache is populated
+is the common trap (see issue #49).
+
+If you want to manage a connection yourself — e.g. to open an existing
+duckdb database file, or to share a connection across other DBI-based
+code — create it directly and pass it to \code{duckdbfs} functions via
+the \code{conn} argument:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{con <- DBI::dbConnect(duckdb::duckdb(), dbdir = "my.duckdb")
+open_dataset("s3://bucket/data", conn = con)
+}\if{html}{\out{</div>}}
+
+See the "File-based vs database-based workflows" article for the broader
+design philosophy.
+}
+
 \examples{
 \dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 

--- a/man/to_sf.Rd
+++ b/man/to_sf.Rd
@@ -9,7 +9,10 @@ to_sf(x, crs = NA, conn = cached_connection())
 \arguments{
 \item{x}{a remote duckdb \code{tbl} (from \code{open_dataset}) or dplyr-pipeline thereof.}
 
-\item{crs}{The coordinate reference system, any format understood by \code{sf::st_crs}.}
+\item{crs}{The coordinate reference system, any format understood by \code{sf::st_crs}.
+If \code{NA} (the default), \code{to_sf()} will pick up the CRS from the column's
+\code{GEOMETRY('...')} type annotation when one is present (e.g. when reading
+a georeferenced file via \code{open_dataset(format = "sf")}).}
 
 \item{conn}{the connection object from the tbl.
 Takes a duckdb table (from \code{open_dataset}) or a dataset or dplyr

--- a/vignettes/articles/file-vs-database.Rmd
+++ b/vignettes/articles/file-vs-database.Rmd
@@ -1,0 +1,120 @@
+---
+title: "File-based vs database-based workflows"
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+## TL;DR
+
+`duckdbfs` is designed around a **file-first** workflow: treat parquet / CSV
+/ spatial files (local or remote) as the source of truth, build a lightweight
+DuckDB **VIEW** over them, and query that with `dplyr`. You almost never need
+to import data into a DuckDB *table* first. This is a deliberate inversion of
+the classic database mental model, and it's worth explaining why — and when
+to break the rule.
+
+## Files + VIEWs (the default)
+
+```{r}
+library(duckdbfs)
+library(dplyr)
+
+tbl <- open_dataset("s3://some-bucket/data.parquet")
+tbl |>
+  filter(year == 2024) |>
+  summarise(mean_temp = mean(temp))
+```
+
+What happens here:
+
+- `open_dataset()` creates a DuckDB VIEW pointing at the remote parquet file.
+  Nothing is downloaded; no table is materialised.
+- The VIEW takes ~zero disk space and no RAM.
+- `dplyr` verbs translate to SQL via `dbplyr`; the query is pushed to DuckDB,
+  which streams only the bytes it needs (parquet column chunks, S3 range
+  requests, HTTP byte ranges).
+
+This pattern scales to datasets much larger than RAM and larger than local
+disk, because the data never leaves its source.
+
+## Databases + TABLES (the escape hatch)
+
+Importing remote data into a local DuckDB table looks natural to users coming
+from PostgreSQL or SQLite, but for most cloud-native data workloads it is a
+pessimisation:
+
+- It downloads the *entire* dataset (not just the columns or row groups you
+  need).
+- It decompresses and re-encodes into DuckDB's native format, often blowing
+  up disk footprint.
+- On very large datasets it can exhaust RAM or `/tmp` during the import,
+  crashing the machine.
+
+There are, however, real cases where a local table *is* the right call:
+
+1. **You're going to query the same data many times on a slow network.** One
+   one-time download amortises across many queries.
+2. **You need an index DuckDB can only build on stored tables.** The spatial
+   extension's R-tree index (`CREATE INDEX ... USING RTREE`) is the canonical
+   example.
+3. **You need a persistent on-disk database that other tools will share.**
+
+For (1) and (2), use `mode = "TABLE"` in `open_dataset()` and point
+`cached_connection()` at a disk location so DuckDB doesn't try to hold the
+table in RAM:
+
+```{r}
+con <- cached_connection("/path/to/storage")
+open_dataset("s3://bucket/big-data", conn = con, mode = "TABLE")
+```
+
+For (3), manage the connection yourself:
+
+```{r}
+con <- DBI::dbConnect(duckdb::duckdb(), dbdir = "shared.duckdb")
+open_dataset("local/data.parquet", conn = con)
+DBI::dbExecute(con, "CREATE TABLE cached AS SELECT * FROM ...")
+```
+
+## The sticky-cache gotcha
+
+`cached_connection()` is cached *by design* — it caches the first connection
+it makes and returns that same object on every subsequent call, so internal
+duckdbfs functions share one connection. The trap: if the first call happened
+implicitly (e.g. inside some earlier `open_dataset()` call that created the
+default in-memory connection), a *later* call like
+`cached_connection(dbdir = "my.duckdb")` will silently ignore the `dbdir`
+argument and return the cached in-memory connection.
+
+If you want a disk-backed connection, either:
+
+- Call `cached_connection(dbdir = ...)` **before any other duckdbfs
+  operation**, or
+- Call `close_connection()` to drop the cached one, then re-create with
+  your desired `dbdir`.
+
+This was the source of confusion in
+[#49](https://github.com/cboettig/duckdbfs/issues/49).
+
+## The "R user" framing
+
+Most R users come to data work through the
+`read_csv() |> dplyr::... |> write_csv()` pipeline — data lives in *files*,
+is loaded in memory for a session, then written back out. `duckdbfs` tries
+to preserve that mental model but extend it to datasets that don't fit in
+RAM, and to remote sources that can't be read by base-R connections. The
+`fs` in `duckdbfs` stands for *filesystem*.
+
+Tools like [ibis](https://ibis-project.org) (Python) use an identical design
+on top of DuckDB: open a file, get a lazy relation, push computation down via
+SQL, collect only what you need. If you already think in that idiom, the
+duckdbfs defaults should feel familiar. If you're coming from a
+database-administration background, think of `open_dataset()` as producing
+a VIEW rather than a TABLE — and reach for TABLE mode only when you need
+what a TABLE gives you (indexing, persistence, multi-process access).


### PR DESCRIPTION
## Summary

Two documentation additions driven by #49:

1. **\`cached_connection()\` roxygen** — adds an *On-disk storage and the connection cache* section that:
   - Documents the \`dbdir = \"/path/to.duckdb\"\` option explicitly.
   - Calls out the sticky-cache gotcha: once the cache is populated (often implicitly by an earlier \`open_dataset()\`), \`dbdir\` on later calls is silently ignored. This is exactly what tripped up #49.
   - Points users at \`DBI::dbConnect(duckdb::duckdb(), dbdir = ...)\` for the "I want to use my existing duckdb database file" case.

2. **New pkgdown article** — \`vignettes/articles/file-vs-database.Rmd\` — covers the broader design philosophy: file + VIEW as the default for cloud-native workflows, TABLE mode as an escape hatch, and when each is the right call. Pkgdown-only (no CRAN/vignette build cost).

## Why

The mechanism was already there, but the design rationale only lived in an issue thread. #49 ended with the user figuring it out themselves — docs should make that figuring-out unnecessary.

## Test plan

- [x] \`devtools::document()\` regenerates cleanly
- [x] \`devtools::test()\` — FAIL 0 | PASS 72
- [x] \`rmarkdown::render()\` on the article produces valid HTML
- [ ] Pkgdown build on CI publishes the article